### PR TITLE
Fixes review deletions bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -433,6 +433,7 @@ class DiscardRevision(webapp2.RequestHandler):
         si = selected_item.get()
         si.approved = True
         si.outdated = False
+        si.child = None
         si.put()
         discarded_item = ndb.Key(urlsafe=self.request.get('newest_id'))
         while discarded_item != selected_item:


### PR DESCRIPTION
Deleted items could sometimes not be seen if they had previously been reverted from a newer edit. This was caused by forgetting to mark the child as None when reverting an item.